### PR TITLE
Don't trigger action when button is still being pressed

### DIFF
--- a/daemon/src/mapping.rs
+++ b/daemon/src/mapping.rs
@@ -194,7 +194,7 @@ fn poll(mappings: MappingDirectory, peer_map: crate::PeerMap) -> sysfs_gpio::Res
             }
 
             // Resets button press sequence timer
-            if (get_timestamp() - last_press_time) > SEQUENCE_DELAY &&
+            if !button_state && (get_timestamp() - last_press_time) > SEQUENCE_DELAY &&
 		!button_press_vec.is_empty() {
                 trigger_action(&mappings, &button_press_vec, &peer_map);
                 button_press_vec.clear();


### PR DESCRIPTION
The action would be triggered even if the button is currently being pressed.
This change allows for button press sequences that are longer than SEQUENCE_DELAY.